### PR TITLE
version update and related changes

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -2,11 +2,11 @@
 # Variables here are applicable to all host groups
 
 # Select the Mesos package version install:
-mesos_pkg_version: 0.20.0-1.0.ubuntu1404
+mesos_pkg_version: 0.23.0-1.0.ubuntu1404
 
 # Choose whether to install Marathon using a Mesosphere package or from GitHub source
 marathon_install_type: "package" # valid options are "package" or "source"
-marathon_pkg_version: 0.6.1-1.1 # if install type is "package" which version to use
+marathon_pkg_version: 0.9.1-1.0.393.ubuntu1404 # if install type is "package" which version to use
 
 mesos_local_address: "{{ansible_eth0.ipv4.address}}"
 mesos_cluster_name: "Cluster01"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -4,17 +4,9 @@
   apt_key: url=http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0xE56151BF state=present
   sudo: yes
 
-- name: Determine Linux distribution distributor
-  shell: lsb_release -is | tr '[:upper:]' '[:lower:]'
-  register: release_distributor
-
-- name: Determine Linux distribution codename
-  command: lsb_release -cs
-  register: release_codename
-
 - name: Add Mesosphere repository to sources list
   copy:
-    content: "deb http://repos.mesosphere.io/{{release_distributor.stdout}} {{release_codename.stdout}} main"
+    content: "deb http://repos.mesosphere.io/{{ansible_lsb.id | lower}} {{ansible_lsb.codename}} main"
     dest: /etc/apt/sources.list.d/mesosphere.list
     mode: 0644
   sudo: yes

--- a/roles/marathon/tasks/main.yml
+++ b/roles/marathon/tasks/main.yml
@@ -44,8 +44,19 @@
   sudo: yes
   when: marathon_install_type == "package" and marathon_only == True
 
-- name: Create Marathon Upstart job for packaged version
-  template: src=marathon.conf.j2 dest=/etc/init/marathon.conf
+- name: Create marathon conf directory
+  file:
+    path: /etc/marathon/conf/
+    state: directory
+    mode: 0755
+  sudo: yes
+  when: marathon_install_type == "package"
+
+- name: Set Marathon hostname
+  copy:
+    content: "{{mesos_local_address}}"
+    dest: /etc/marathon/conf/hostname
+    mode: 0644
   sudo: yes
   notify:
     - Restart marathon

--- a/roles/marathon/templates/marathon.conf.j2
+++ b/roles/marathon/templates/marathon.conf.j2
@@ -1,9 +1,0 @@
-description "Marathon scheduler for Mesos"
-
-start on runlevel [2345]
-stop on runlevel [!2345]
-
-respawn
-respawn limit 10 5
-
-exec /usr/local/bin/marathon{% if groups.marathon|count > 1 %} --ha{% endif %} --hostname {{ mesos_local_address }}

--- a/roles/mesos/tasks/main.yml
+++ b/roles/mesos/tasks/main.yml
@@ -84,13 +84,3 @@
     mode: 0644
   sudo: yes
   when: mesos_install_mode == "slave" or mesos_install_mode == "master-slave"
-
-- name: Set Mesos Slave isolation
-  copy:
-    content: "cgroups/cpu,cgroups/mem"
-    dest: /etc/mesos-slave/isolation
-    mode: 0644
-  sudo: yes
-  notify:
-    - Start mesos-slave
-  when: mesos_install_mode == "slave" or mesos_install_mode == "master-slave"


### PR DESCRIPTION
Bumped mesos and marathon versions to latest releases,

Removed unnecessary 'Set Mesos Slave isolation' task, given value is already the default in current version,

Removed 'Create Marathon Upstart job for packaged version' task, since it's overriding the config from package, Marathon package has it's own configuration method,

Got rid of --ha parameter for Marathon since its default,

Moved Marathon's `hostname` parameter from upstart template to /etc/marathon/ directory,

Marathon executable path in upstart marathon config(roles/marathon/templates/marathon.conf.j2) was wrong ('/usr/local/bin' should be '/usr/bin/marathon').
